### PR TITLE
mark as superseded and direct to {xaringanBuilder}

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
 # xaringanPrinter
 
 <!-- badges: start -->
+[![Lifecycle: superseded](https://img.shields.io/badge/lifecycle-superseded-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html#superseded)
 <!-- badges: end -->
 
 The goal of xaringanPrinter is to provide an easy interface to convert xaringan (remark.js) slides to other formats.
@@ -38,7 +39,7 @@ remotes::install_github("EvaMaeRey/xaringanPrinter")
 
 This is a basic example which shows you how to solve a common problem:
 
-```{r example}
+```{r example, eval = FALSE}
 library(xaringanPrinter)
 ## basic example code
 ```
@@ -50,3 +51,6 @@ slides_gif(input = "my_slideshow.html", output = "a_folder/my_slideshow.gif")
 
 This will produce "my_slideshow.gif" in "a_folder".
 
+# Superseded
+
+This package is no longer being developed. Current work regarding outputting `{xaringan}` slides into different formats has coalesced around [Jhelvy/xaringanBuilder](https://github.com/jhelvy/xaringanBuilder).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 <!-- badges: start -->
 
+[![Lifecycle:
+superseded](https://img.shields.io/badge/lifecycle-superseded-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html#superseded)
 <!-- badges: end -->
 
 The goal of xaringanPrinter is to provide an easy interface to convert
@@ -42,3 +44,10 @@ slides_gif(input = "my_slideshow.html", output = "a_folder/my_slideshow.gif")
 ```
 
 This will produce “my\_slideshow.gif” in “a\_folder”.
+
+# Superseded
+
+This package is no longer being developed. Current work regarding
+outputting `{xaringan}` slides into different formats has coalesced
+around
+[Jhelvy/xaringanBuilder](https://github.com/jhelvy/xaringanBuilder).


### PR DESCRIPTION
Changed README.RMD and README.md to add lifecycle badge of superseded and point people to xaringanBuilder.